### PR TITLE
Remove data_type from HEW JSON inputs

### DIFF
--- a/src/pyrenew_multisignal/hew/data.py
+++ b/src/pyrenew_multisignal/hew/data.py
@@ -98,7 +98,6 @@ class PyrenewHEWData:
                     "geo_value": pl.String,
                     "observed_ed_visits": pl.Float64,
                     "other_ed_visits": pl.Float64,
-                    "data_type": pl.String,
                 },
             )
             if fit_ed_visits
@@ -111,7 +110,6 @@ class PyrenewHEWData:
                     "weekendingdate": pl.Date,
                     "jurisdiction": pl.String,
                     "hospital_admissions": pl.Float64,
-                    "data_type": pl.String,
                 },
             )
             if fit_hospital_admissions

--- a/tests/test_pyrenew_hew_data.py
+++ b/tests/test_pyrenew_hew_data.py
@@ -309,7 +309,6 @@ def test_from_json(tmp_path, fit_ed_visits, fit_hospital_admissions, fit_wastewa
     # Verify ED visits data
     if fit_ed_visits:
         assert data.nssp_training_data is not None
-        assert "data_type" not in data.nssp_training_data.columns
         assert data.data_observed_disease_ed_visits is not None
     else:
         assert data.nssp_training_data is None
@@ -318,7 +317,6 @@ def test_from_json(tmp_path, fit_ed_visits, fit_hospital_admissions, fit_wastewa
     # Verify hospital admissions data
     if fit_hospital_admissions:
         assert data.nhsn_training_data is not None
-        assert "data_type" not in data.nhsn_training_data.columns
         assert data.data_observed_disease_hospital_admissions is not None
     else:
         assert data.nhsn_training_data is None

--- a/tests/test_pyrenew_hew_data.py
+++ b/tests/test_pyrenew_hew_data.py
@@ -223,7 +223,6 @@ def _build_mock_data(fit_ed_visits, fit_hospital_admissions, fit_wastewater):
             "geo_value": ["CA"] * 2,
             "other_ed_visits": [200, 400],
             "observed_ed_visits": [10, 3],
-            "data_type": ["train"] * 2,
         },
         "nssp_training_dates": ["2025-01-01"],
         "nssp_step_size": 1,
@@ -234,7 +233,6 @@ def _build_mock_data(fit_ed_visits, fit_hospital_admissions, fit_wastewater):
             "weekendingdate": ["2025-01-01", "2025-01-02"],
             "jurisdiction": ["CA"] * 2,
             "hospital_admissions": [5, 1],
-            "data_type": ["train"] * 2,
         },
         "nhsn_training_dates": ["2025-01-04"],
         "nhsn_step_size": 7,
@@ -311,6 +309,7 @@ def test_from_json(tmp_path, fit_ed_visits, fit_hospital_admissions, fit_wastewa
     # Verify ED visits data
     if fit_ed_visits:
         assert data.nssp_training_data is not None
+        assert "data_type" not in data.nssp_training_data.columns
         assert data.data_observed_disease_ed_visits is not None
     else:
         assert data.nssp_training_data is None
@@ -319,6 +318,7 @@ def test_from_json(tmp_path, fit_ed_visits, fit_hospital_admissions, fit_wastewa
     # Verify hospital admissions data
     if fit_hospital_admissions:
         assert data.nhsn_training_data is not None
+        assert "data_type" not in data.nhsn_training_data.columns
         assert data.data_observed_disease_hospital_admissions is not None
     else:
         assert data.nhsn_training_data is None


### PR DESCRIPTION
## Summary

- stop requiring `data_type` in NSSP and NHSN JSON inputs
- define strict schemas containing only the columns consumed by `PyrenewHEWData`

## Why

`data_for_model_fit.json` is already restricted to training observations, so downstream model loaders should not need a training/evaluation marker. This unblocks CDCgov/cfa-stf-routine-forecasting#1188.

## Validation

- `uv run pytest tests/test_pyrenew_hew_data.py -q` (41 passed)
- `uv run pytest -m 'not integration' -q` (75 passed, 3 deselected)
- targeted pre-commit hooks
